### PR TITLE
fix: don't check tempdir writeability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## CHARLIE development version
 
+- Fix bug where CHARLIE was falsely throwing a file permissions error for tempdir values containing bash variables. (#118, @kelly-sovacool)
+
 ## CHARLIE 0.11.0
 
 - Major updates to convert CHARLIE from a biowulf-specific to a platform-agnostic pipeline (#102, @kelly-sovacool):

--- a/workflow/rules/init.smk
+++ b/workflow/rules/init.smk
@@ -87,8 +87,6 @@ def _convert_to_int(variable):
 # resource absolute path
 WORKDIR = config["workdir"]
 TEMPDIR = config["tempdir"]
-if not os.access(TEMPDIR, os.W_OK):
-    raise PermissionError(f"TEMPDIR {TEMPDIR} cannot be written to.\n\tHint: does the path exist and do you have write permissions?")
 
 SCRIPTS_DIR = config["scriptsdir"]
 RESOURCES_DIR = config["resourcesdir"]


### PR DESCRIPTION
if `config['tempdir']` contains a bash variable, it won't be interpolated properly in python and charlie will falsely say that it is not writeable.

interpolating bash variables may raise a security issue, so I think it's better not to check and just let an error happen later (during a rule that uses the tempdir) if the user sets `tempdir` to an unwriteable location.

## Issues

fixes #117 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
