### PR TITLE
fix: reconfig needs to use platform-specific configfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - CHARLIE was falsely throwing a file permissions error for tempdir values containing bash variables. (#118, @kelly-sovacool)
 - Singularity bind paths were not being set properly. (#119, @kelly-sovacool)
+- Update docker containers to set `$PYTHONPATH`. (#119, @kelly-sovacool)
+  - Otherwise, this environment variable can be carried over and cause package conflicts when singularity is not run with `-C`.
+- Fix `reconfig` to correctly replace variables in the config file. (#121, @kelly-sovacool)
 
 ## CHARLIE 0.11.0
 

--- a/charlie
+++ b/charlie
@@ -295,7 +295,7 @@ function reconfig(){
   # this is only for dev purposes when new key-value pairs are being added to the config file
   check_essential_files
   sed -e "s/PIPELINE_HOME/${PIPELINE_HOME//\//\\/}/g" -e "s/WORKDIR/${WORKDIR//\//\\/}/g" \
-  ${PIPELINE_HOME}/config/config.yaml |\
+  ${PIPELINE_HOME}/config/$PLATFORM/config.yaml |\
   cat - ${PIPELINE_HOME}/config/containers.yaml > $WORKDIR/config.yaml
   echo "$WORKDIR/config.yaml has been updated!"
 }

--- a/charlie
+++ b/charlie
@@ -294,9 +294,13 @@ function reconfig(){
   # rebuild config file and replace the config.yaml in the WORKDIR
   # this is only for dev purposes when new key-value pairs are being added to the config file
   check_essential_files
-  sed -e "s/PIPELINE_HOME/${PIPELINE_HOME//\//\\/}/g" -e "s/WORKDIR/${WORKDIR//\//\\/}/g" \
-  ${PIPELINE_HOME}/config/$PLATFORM/config.yaml |\
-  cat - ${PIPELINE_HOME}/config/containers.yaml > $WORKDIR/config.yaml
+  sed -e "s/PIPELINE_HOME/${PIPELINE_HOME//\//\\/}/g" \
+    -e "s/WORKDIR/${WORKDIR//\//\\/}/g" \
+    -e "s/HOST/${HOST}/g" \
+    -e "s/ADDITIVES/${ADDITIVES}/g" \
+    -e "s/VIRUSES/${VIRUSES}/g" \
+    ${PIPELINE_HOME}/config/$PLATFORM/config.yaml |\
+    cat - ${PIPELINE_HOME}/config/containers.yaml > $CONFIGFILE
   echo "$WORKDIR/config.yaml has been updated!"
 }
 


### PR DESCRIPTION
## Changes

update `reconfig` mode to use the new(er) platform-specific config file.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
