### PR TITLE
fix: additional python paths in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - CHARLIE was falsely throwing a file permissions error for tempdir values containing bash variables. (#118, @kelly-sovacool)
 - Singularity bind paths were not being set properly. (#119, @kelly-sovacool)
-- Update docker containers to set `$PYTHONPATH`. (#119, @kelly-sovacool)
+- Update docker containers to set `$PYTHONPATH`. (#119, #125, @kelly-sovacool)
   - Otherwise, this environment variable can be carried over and cause package conflicts when singularity is not run with `-C`.
 - Fix `reconfig` to correctly replace variables in the config file. (#121, @kelly-sovacool)
 

--- a/config/containers.yaml
+++ b/config/containers.yaml
@@ -1,5 +1,5 @@
 containers:
-  base: "docker://nciccbr/ccbr_ubuntu_base_20.04:v6"
+  base: "docker://nciccbr/ccbr_ubuntu_base_20.04:v7"
   bowtie1: "docker://nciccbr/charlie_bowtie1:v0.1.1"
   circexplorer: "docker://nciccbr/ccbr_circexplorer:v1.0"
   circRNA_finder: "docker://nciccbr/charlie_circrna_finder:v1.0.1"

--- a/workflow/rules/post_findcircrna_processing.smk
+++ b/workflow/rules/post_findcircrna_processing.smk
@@ -444,24 +444,25 @@ rule create_hq_bams:
         additives=ADDITIVES,
         viruses=VIRUSES,
     container: config['containers']["base"]
-    shell:"""
-set -exo pipefail
-outdir=$(dirname {output.outbam})
-if [ ! -d $outdir ];then mkdir -p $outdir;fi
-cd $outdir
-python3 {params.script} \\
-    -i {input.inbam} \\
-    -t {input.countstable} \\
-    -o {output.outbam} \\
-    --regions {params.regions} \\
-    --host "{params.host}" \\
-    --additives "{params.additives}" \\
-    --viruses "{params.viruses}" \\
-    --sample_name {params.samplename}
-samtools index {output.outbam}
-for bam in $(ls {params.samplename}.*.HQ_only.BSJ.bam);do
-    if [ ! -f "${{bam}}.bai" ];then
-        samtools index $bam
-    fi
-done
-"""
+    shell:
+        """
+        set -exo pipefail
+        outdir=$(dirname {output.outbam})
+        if [ ! -d $outdir ];then mkdir -p $outdir;fi
+        cd $outdir
+        python3 {params.script} \\
+            -i {input.inbam} \\
+            -t {input.countstable} \\
+            -o {output.outbam} \\
+            --regions {params.regions} \\
+            --host "{params.host}" \\
+            --additives "{params.additives}" \\
+            --viruses "{params.viruses}" \\
+            --sample_name {params.samplename}
+        samtools index {output.outbam}
+        for bam in $(ls {params.samplename}.*.HQ_only.BSJ.bam);do
+            if [ ! -f "${{bam}}.bai" ];then
+                samtools index $bam
+            fi
+        done
+        """

--- a/workflow/rules/post_findcircrna_processing.smk
+++ b/workflow/rules/post_findcircrna_processing.smk
@@ -278,20 +278,21 @@ rule create_circExplorer_merged_found_counts_table:
         ),
         outdir=join(WORKDIR, "results", "{sample}", "circExplorer"),
         tmpdir=f"{TEMPDIR}/{str(uuid.uuid4())}",
+    container: config['containers']['star_ucsc_cufflinks']
     shell:
         """
-set -exo pipefail
-mkdir -p {params.tmpdir}
-python3 {params.pythonscript} \\
-    -b {input.bsj_found_counts} \\
-    -l {input.linear_spliced_counts} \\
-    -o {output.found_counts_table}
+        set -exo pipefail
+        mkdir -p {params.tmpdir}
+        python3 {params.pythonscript} \\
+            -b {input.bsj_found_counts} \\
+            -l {input.linear_spliced_counts} \\
+            -o {output.found_counts_table}
 
-python3 {params.pythonscript2} \\
-    --annotationcounts {input.annotation_counts} \\
-    --allfoundcounts {output.found_counts_table} \\
-    --countstable {output.count_counts_table}
-"""
+        python3 {params.pythonscript2} \\
+            --annotationcounts {input.annotation_counts} \\
+            --allfoundcounts {output.found_counts_table} \\
+            --countstable {output.count_counts_table}
+        """
 
 
 if RUN_MAPSPLICE:


### PR DESCRIPTION
## Changes

- `create_circExplorer_merged_found_counts_table` - set container
- `create_hq_bams` - base container needs to be updated with pythonpath
  - upgrade base container to v7: https://github.com/CCBR/Dockers/pull/35 

## Issues

- resolves #124
- depends on https://github.com/CCBR/Dockers/issues/33

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
