### PR TITLE
concatenate reference files without using excessive memory

### DIFF
--- a/workflow/rules/init.smk
+++ b/workflow/rules/init.smk
@@ -53,9 +53,8 @@ def append_files_in_list(flist, ofile):
         with open(ofile, "w") as outfile:
             for fname in flist:
                 with open(fname) as infile:
-                    l = infile.read()
-                    l = l.strip()
-                    outfile.write("%s\n" % (l))
+                    for line in infile:
+                        outfile.write(line)
     return True
 
 


### PR DESCRIPTION
## Changes

Read & write files line-by-line instead of reading entire input files into RAM.

## Issues

resolves #122 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
